### PR TITLE
Added support for ifelse function (vectorized if-else constructs). 

### DIFF
--- a/R/Deriv.R
+++ b/R/Deriv.R
@@ -395,6 +395,9 @@ Deriv_ <- function(st, x, env, use.D, dsym, scache) {
 		} else if (stch == "(") {
 #browser()
 			return(Simplify(Deriv_(st[[2]], x, env, use.D, dsym, scache), scache=scache))
+		} else if(stch == "ifelse") {
+		  return(Simplify(call("ifelse", st[[2]], Deriv_(st[[3]], x, env, use.D, dsym, scache),
+		                       Deriv_(st[[4]], x, env, use.D, dsym, scache)), scache=scache))
 		} else if (stch == "if") {
 			return(if (nb_args == 2)
 				Simplify(call("if", st[[2]], Deriv_(st[[3]], x, env, use.D, dsym, scache)), scache=scache) else


### PR DESCRIPTION
Support for `ifelse` could not be implemented via the `drule` system, so the `Deriv_` function was modified. Essentially it is the same code as for normal "if-else" constructs when all arguments are present but using a call to `ifelse` instead.
